### PR TITLE
Keepalives

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -22,7 +22,8 @@ const subscriber = Object.assign({}, defaults, {
   channel: null,
   lookup: [],
   concurrency: 1,
-  discoverFrequency: 1000 * 60 * 5 // 5 minutes
+  discoverFrequency: 1000 * 60 * 5, // 5 minutes
+  keepaliveOffset: 500
 })
 
 module.exports = {

--- a/lib/message.js
+++ b/lib/message.js
@@ -24,13 +24,21 @@ class Message {
       writable: true,
       value: this.timestamp.getTime()
     })
+
+    Object.defineProperty(this, 'timer', {
+      enumerable: false,
+      writable: true,
+      value: null
+    })
   }
 
   finish () {
+    clearTimeout(this.timer)
     return this.connection.finish(this.id)
   }
 
   requeue (delay) {
+    clearTimeout(this.timer)
     return this.connection.requeue(this.id, delay)
   }
 
@@ -40,8 +48,30 @@ class Message {
     return res
   }
 
+  async keepalive () {
+    const now = Date.now()
+    // the else condition is not covered because it depends on the max_msg_timeout expiring, which defaults to 15 minutes and is not configurable by the requester
+    /* istanbul ignore else */
+    if (!this.expired) {
+      await this.touch()
+      this.timer = setTimeout(() => this.keepalive(), this.touched + this.connection.features.msg_timeout - now - this.connection.options.keepaliveOffset)
+    }
+  }
+
+  get expired () {
+    const now = Date.now()
+    return this.touched + this.connection.features.msg_timeout < now || this.published.getTime() + this.connection.features.max_msg_timeout < now
+  }
+
   get expiresIn () {
-    return this.touched + this.connection.features.msg_timeout - Date.now()
+    const now = Date.now()
+    // if the timer is set, we're keeping the message alive and the value returned here will not account for the msg_timeout
+    if (this.timer) {
+      return this.published.getTime() + this.connection.features.max_msg_timeout - now
+    }
+
+    // if the timer is not set, we return whichever timeout will occur first
+    return Math.min(this.touched + this.connection.features.msg_timeout - now, this.published.getTime() + this.connection.features.max_msg_timeout - now)
   }
 }
 

--- a/test/discoverer-test.js
+++ b/test/discoverer-test.js
@@ -184,7 +184,7 @@ test('discoverer skips lookup hosts that 404', async (assert) => {
 
   const subscriber = new Squeaky.Subscriber({ lookup: ['127.0.0.1:41616'], discoverFrequency: 100, topic, channel: 'test#ephemeral', ...getSubDebugger() })
 
-  await new Promise((resolve) => subscriber.on('error', (err) => {
+  await new Promise((resolve) => subscriber.on('warn', (err) => {
     assert.equals(err.code, 'ELOOKUPERROR')
     assert.equals(err.host, 'http://127.0.0.1:41616')
     resolve()
@@ -208,7 +208,7 @@ test('discoverer skips lookup hosts that return invalid json', async (assert) =>
 
   const subscriber = new Squeaky.Subscriber({ lookup: ['127.0.0.1:41616'], discoverFrequency: 100, topic, channel: 'test#ephemeral', ...getSubDebugger() })
 
-  await new Promise((resolve) => subscriber.on('error', (err) => {
+  await new Promise((resolve) => subscriber.on('warn', (err) => {
     assert.equals(err.code, 'ELOOKUPERROR')
     assert.equals(err.host, 'http://127.0.0.1:41616')
     resolve()
@@ -225,7 +225,7 @@ test('discoverer skips lookup hosts that cannot be reached', async (assert) => {
 
   const subscriber = new Squeaky.Subscriber({ lookup: ['127.0.0.1:41616'], discoverFrequency: 100, topic, channel: 'test#ephemeral', ...getSubDebugger() })
 
-  await new Promise((resolve) => subscriber.on('error', (err) => {
+  await new Promise((resolve) => subscriber.on('warn', (err) => {
     assert.equals(err.code, 'ELOOKUPERROR')
     assert.equals(err.host, 'http://127.0.0.1:41616')
     resolve()


### PR DESCRIPTION
This is somewhat annoying to implement outside of squeaky due to variations in the underlying connection each message may have come from, as well as differentiating between a timeout that can be renewed and one that cannot.

Good news is it's simple to implement here, so I did.