### PR TITLE
fix: Use timestamp instead of published in message keepalive logic

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -60,18 +60,18 @@ class Message {
 
   get expired () {
     const now = Date.now()
-    return this.touched + this.connection.features.msg_timeout < now || this.published.getTime() + this.connection.features.max_msg_timeout < now
+    return this.touched + this.connection.features.msg_timeout < now || this.timestamp.getTime() + this.connection.features.max_msg_timeout < now
   }
 
   get expiresIn () {
     const now = Date.now()
     // if the timer is set, we're keeping the message alive and the value returned here will not account for the msg_timeout
     if (this.timer) {
-      return this.published.getTime() + this.connection.features.max_msg_timeout - now
+      return this.timestamp.getTime() + this.connection.features.max_msg_timeout - now
     }
 
     // if the timer is not set, we return whichever timeout will occur first
-    return Math.min(this.touched + this.connection.features.msg_timeout - now, this.published.getTime() + this.connection.features.max_msg_timeout - now)
+    return Math.min(this.touched + this.connection.features.msg_timeout - now, this.timestamp.getTime() + this.connection.features.max_msg_timeout - now)
   }
 }
 

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -154,12 +154,17 @@ test('can keep a message alive', async (assert) => {
     await msg.keepalive()
     assert.ok(msg.expiresIn - msg.connection.features.max_msg_timeout < 25, 'expiresIn is based on max_msg_timeout')
     setTimeout(async () => {
+      const now = Date.now()
       assert.equal(msg.expired, false, 'message has not expired')
+      assert.ok(
+        msg.expiresIn - (msg.published.getTime() + msg.connection.features.max_msg_timeout - now) > 2000,
+        'expiresIn should depend on message timestamp, not publication time'
+      )
       await msg.finish()
       resolver()
     }, 1500)
   })
-  await publisher.publish(topic, { some: 'object' })
+  await publisher.publish(topic, { some: 'object' }, 2000)
 
   await received
   await Promise.all([


### PR DESCRIPTION
Should address https://github.com/nlf/squeaky/issues/8 ?